### PR TITLE
Changing "Save" button color whenever a draft is available

### DIFF
--- a/src/js/components/AutoSave.tsx
+++ b/src/js/components/AutoSave.tsx
@@ -7,6 +7,8 @@ export default observer(() => {
   const { saved, autoSaveHandle } = useStore().AppStore
   const content =
     (autoSaveHandle && <CircularProgress size={24} />) ||
-    (saved && <InputLabel>Draft saved</InputLabel>)
+    (saved && (
+      <InputLabel>Draft saved. Click "Save" to apply the script.</InputLabel>
+    ))
   return <span>{content}</span>
 })

--- a/src/js/components/Save.tsx
+++ b/src/js/components/Save.tsx
@@ -4,12 +4,13 @@ import { useStore } from './StoreContext'
 import { observer } from 'mobx-react'
 
 export default observer(({ onSave }) => {
-  const { differentURL, tabMode } = useStore().AppStore
+  const { differentURL, tabMode, saved, draft } = useStore().AppStore
   return (
     <Button
       color='primary'
       disabled={differentURL && !tabMode}
       onClick={onSave}
+      style={(saved || draft) && { backgroundColor: '#f50057', color: 'white' }}
     >
       Save
     </Button>

--- a/src/js/components/Save.tsx
+++ b/src/js/components/Save.tsx
@@ -7,10 +7,9 @@ export default observer(({ onSave }) => {
   const { differentURL, tabMode, saved, draft } = useStore().AppStore
   return (
     <Button
-      color='primary'
+      color={saved || draft ? 'secondary' : 'primary'}
       disabled={differentURL && !tabMode}
       onClick={onSave}
-      style={(saved || draft) && { backgroundColor: '#f50057', color: 'white' }}
     >
       Save
     </Button>


### PR DESCRIPTION
Hello,

I've been using this extension for some time now, so I thought I'd contibute to it.

This fixes #60 by turning the `Save` button red whenever there's a saved draft.

Also changed the 

> Draft saved.

 label to 

> Draft saved. Click "Save" to apply the script.

Below is a screenshot with the changes:

![screenshot](https://user-images.githubusercontent.com/18372991/71863692-6f82c180-30dc-11ea-94ab-248c262e2ed1.JPG)
